### PR TITLE
Only include the security posts on Gabriel Corona's blog

### DIFF
--- a/feeds.txt
+++ b/feeds.txt
@@ -3,4 +3,4 @@ https://cryptologie.net/feed/index/html
 https://research.securitum.com/feed/
 https://textslashplain.com/feed/
 https://www.sjoerdlangkemper.nl/feed.xml
-https://www.gabriel.urdhr.fr/feed.atom
+https://www.gabriel.urdhr.fr/tags/security/feed.atom


### PR DESCRIPTION
This would avoid the bot tweeting things which are completely unrelated to infosec :)

Alternatively this feed could be used: https://www.gabriel.urdhr.fr/tags/computer/feed.atom